### PR TITLE
Solve #8  ESPHome logger issue

### DIFF
--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -48,7 +48,7 @@ sensor:
 
 # To be able to get logs from the device via serial and api.
 logger:
-
+  level: NONE
 # API is a requirement of the dashboard import.
 api:
 


### PR DESCRIPTION
When the logger is enabled and the USB is not start communication the FreeRTOS watchdog fires