### PR TITLE
Create manual calibration option for noisy environments or unsupported water meters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           yaml-file: ${{ matrix.file }}.yaml
           version: ${{ matrix.esphome-version }}
-      # - name: ESPHome ${{ matrix.esphome-version }} Factory
-      #   uses: esphome/build-action@v4.0.3
-      #   with:
-      #     yaml-file: ${{ matrix.file }}.factory.yaml
-      #     version: ${{ matrix.esphome-version }}
+      - name: ESPHome ${{ matrix.esphome-version }} Factory
+        uses: esphome/build-action@v4.0.3
+        with:
+          yaml-file: ${{ matrix.file }}.factory.yaml
+          version: ${{ matrix.esphome-version }}

--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       #### Modify below here to match your project ####
       files: |
-        muino-water-meter-esp32.yaml
+        muino-water-meter-esp32.factory.yaml
       esphome-version: 2024.10.3
       combined-name: project-template
       #### Modify above here to match your project ####

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 # You can modify this file to suit your needs.
 /.esphome/
 /secrets.yaml
+test*
+pushmsg
+imgui.ini
+*.log

--- a/muino-water-meter-esp32.factory.yaml
+++ b/muino-water-meter-esp32.factory.yaml
@@ -7,7 +7,7 @@ esphome:
   # configuration and updates.
   project:
   name: esphome.muino-water-meter
-    version: dev # This will be replaced by the github workflows with the `release` version
+  version: dev # This will be replaced by the github workflows with the `release` version
 
 # This should point to the public location of the yaml file that will be adopted.
 # In this case it is the core yaml file that does not contain the extra things

--- a/muino-water-meter-esp32.factory.yaml
+++ b/muino-water-meter-esp32.factory.yaml
@@ -1,0 +1,25 @@
+packages:
+  # Include all of the core configuration
+  core: !include project-template-esp32-c3.yaml
+
+esphome:
+  # This will allow for project identification,
+  # configuration and updates.
+  project:
+    name: esphome.project-template
+    version: dev # This will be replaced by the github workflows with the `release` version
+
+# This should point to the public location of the yaml file that will be adopted.
+# In this case it is the core yaml file that does not contain the extra things
+# that are provided by this factory yaml file as the user does not need these once adopted.
+dashboard_import:
+  package_import_url: github://martijnvwezel/watermeter-esphome/muino-water-meter-esp32.yaml@main
+
+# Sets up Bluetooth LE (Only on ESP32) to allow the user
+# to provision wifi credentials to the device.
+# esp32_improv:
+#   authorizer: none
+
+# Sets up the improv via serial client for Wi-Fi provisioning.
+# Handy if your device has a usb port for the user to add credentials when they first get it.
+# improv_serial:

--- a/muino-water-meter-esp32.factory.yaml
+++ b/muino-water-meter-esp32.factory.yaml
@@ -6,7 +6,7 @@ esphome:
   # This will allow for project identification,
   # configuration and updates.
   project:
-    name: esphome_muino-water-meter
+    name: esphome-muino-water-meter
     version: dev # This will be replaced by the github workflows with the `release` version
 
 # This should point to the public location of the yaml file that will be adopted.

--- a/muino-water-meter-esp32.factory.yaml
+++ b/muino-water-meter-esp32.factory.yaml
@@ -6,7 +6,8 @@ esphome:
   # This will allow for project identification,
   # configuration and updates.
   project:
-    name: esphome-muino-water-meter
+    namespace: esphome
+    name: muino-water-meter
     version: dev # This will be replaced by the github workflows with the `release` version
 
 # This should point to the public location of the yaml file that will be adopted.

--- a/muino-water-meter-esp32.factory.yaml
+++ b/muino-water-meter-esp32.factory.yaml
@@ -6,8 +6,7 @@ esphome:
   # This will allow for project identification,
   # configuration and updates.
   project:
-    namespace: esphome
-    name: muino-water-meter
+    name: esphome.muino-water-meter
     version: dev # This will be replaced by the github workflows with the `release` version
 
 # This should point to the public location of the yaml file that will be adopted.

--- a/muino-water-meter-esp32.factory.yaml
+++ b/muino-water-meter-esp32.factory.yaml
@@ -6,7 +6,7 @@ esphome:
   # This will allow for project identification,
   # configuration and updates.
   project:
-  name: esphome.muino-water-meter
+  name: esphome_muino-water-meter
   version: dev # This will be replaced by the github workflows with the `release` version
 
 # This should point to the public location of the yaml file that will be adopted.

--- a/muino-water-meter-esp32.factory.yaml
+++ b/muino-water-meter-esp32.factory.yaml
@@ -1,12 +1,12 @@
 packages:
   # Include all of the core configuration
-  core: !include project-template-esp32-c3.yaml
+  core: !include muino-water-meter-esp32.yaml
 
 esphome:
   # This will allow for project identification,
   # configuration and updates.
   project:
-    name: esphome.project-template
+  name: esphome.muino-water-meter
     version: dev # This will be replaced by the github workflows with the `release` version
 
 # This should point to the public location of the yaml file that will be adopted.

--- a/muino-water-meter-esp32.factory.yaml
+++ b/muino-water-meter-esp32.factory.yaml
@@ -6,8 +6,8 @@ esphome:
   # This will allow for project identification,
   # configuration and updates.
   project:
-  name: esphome_muino-water-meter
-  version: dev # This will be replaced by the github workflows with the `release` version
+    name: esphome_muino-water-meter
+    version: dev # This will be replaced by the github workflows with the `release` version
 
 # This should point to the public location of the yaml file that will be adopted.
 # In this case it is the core yaml file that does not contain the extra things

--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -74,7 +74,6 @@ interval:
   # - interval: 10s # Check every 10 seconds to reduce load, adjust as needed
   #   then:
   #     - lambda: |-
-
   # - interval: 1s
   #   then:
   #     # - component.update: report_liters
@@ -112,6 +111,20 @@ switch:
       - switch.turn_on: fastupdate
     turn_off_action:
       - switch.turn_off: fastupdate
+  # for manual calibration or auto
+  - platform: template
+    id: calibration_mode
+    name: "Manual Calibration"
+    icon: "mdi:tune-vertical"
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON # <--- important
+    turn_on_action:
+      - lambda: |-
+          id(manual_calibration) = true;
+    turn_off_action:
+      - lambda: |-
+          id(manual_calibration) = false;
+
 text_sensor:
   - platform: template
     name: "debug_JSON"
@@ -424,9 +437,18 @@ sensor:
       id(max_b)= max_average(id(max_b), b, alpha_cor);
       id(max_c)= max_average(id(max_c), c, alpha_cor);
 
-      a -= (id(min_a) + id(max_a)) >> 1;
-      b -= (id(min_b) + id(max_b)) >> 1;
-      c -= (id(min_c) + id(max_c)) >> 1;
+      if (id(manual_calibration)) {
+        // Manual offsets
+        a -= id(manual_offset_a);
+        b -= id(manual_offset_b);
+        c -= id(manual_offset_c);
+      } else {
+        // Auto-calibration offsets
+        a -= (id(min_a) + id(max_a)) >> 1;
+        b -= (id(min_b) + id(max_b)) >> 1;
+        c -= (id(min_c) + id(max_c)) >> 1;
+      }
+
       short    pn[5];
       if (id(phase) & 1)
           pn[0] = a + a - b - c, pn[1] = b + b - a - c,
@@ -496,6 +518,69 @@ globals:
   - id: lower_bound
     type: int
     initial_value: "5"
+
+  # Switch that toggles between auto-calibration and manual calibration
+  - id: manual_calibration
+    type: bool
+    restore_value: yes  # <--- important
+    initial_value: "false"
+
+  # Manual offsets for a, b, c
+  - id: manual_offset_a
+    type: int
+    initial_value: "0"
+  - id: manual_offset_b
+    type: int
+    initial_value: "0"
+  - id: manual_offset_c
+    type: int
+    initial_value: "0"
+
+number:
+  - platform: template
+    id: offset_a_number
+    name: "Offset A (0-3300)"
+    restore_value: true       # <--- important
+    initial_value: 0
+    min_value: 0
+    max_value: 3300
+    step: 1
+    set_action:
+      - lambda: |-
+          id(manual_offset_a) = (int) x;  // Set the global
+    on_value:
+      lambda: |-
+          return id(manual_offset_a);     // Return the global
+  - platform: template
+    id: offset_b_number
+    name: "Offset B (0-3300)"
+    restore_value: true       # <--- important
+    initial_value: 0
+    min_value: 0
+    max_value: 3300
+    step: 1
+    set_action:
+      - lambda: |-
+          id(manual_offset_b) = (int) x;
+    on_value:
+      lambda: |-
+          return id(manual_offset_b);     // Return the global
+  - platform: template
+    id: offset_c_number
+    name: "Offset C (0-3300)"
+    restore_value: true       # <--- important
+    initial_value: 0
+    min_value: 0
+    max_value: 3300
+    step: 1
+    set_action:
+      - lambda: |-
+          id(manual_offset_c) = (int) x;
+    on_value:
+      lambda: |-
+          return id(manual_offset_c);     // Return the global
+
+
 
 # Make sure logging is correct for solving platform IO bugs
 logger:

--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -585,9 +585,9 @@ api:
 ota:
   platform: esphome
 
-# This should point to the public location of this yaml file.
-dashboard_import:
-  package_import_url: github://martijnvwezel/watermeter-esphome/muino-water-meter-esp32.yaml@main
+# # This should point to the public location of this yaml file.
+# dashboard_import:
+#   package_import_url: github://martijnvwezel/watermeter-esphome/muino-water-meter-esp32.yaml@main
 
 wifi:
   # Set up a wifi access point using the device name above

--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -14,9 +14,9 @@ esphome:
 
   # This will allow for (future) project identification,
   # configuration and updates.
-  project:
-    name: esphome-muino-water-meter
-    version: "3.0.4"
+  # project:
+  #   name: esphome-muino-water-meter
+  #   version: "3.0.4"
 
 esp32:
   board: seeed_xiao_esp32c3

--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -541,44 +541,43 @@ number:
     id: offset_a_number
     name: "Offset A (0-3300)"
     restore_value: true       # <--- important
+    optimistic: true
     initial_value: 0
     min_value: 0
     max_value: 3300
     step: 1
-    set_action:
-      - lambda: |-
-          id(manual_offset_a) = (int) x;  // Set the global
     on_value:
-      lambda: |-
-          return id(manual_offset_a);     // Return the global
+      then:
+        - lambda: |-
+            id(manual_offset_a) = (int) x;
+
   - platform: template
     id: offset_b_number
     name: "Offset B (0-3300)"
     restore_value: true       # <--- important
+    optimistic: true
     initial_value: 0
     min_value: 0
     max_value: 3300
     step: 1
-    set_action:
-      - lambda: |-
-          id(manual_offset_b) = (int) x;
     on_value:
-      lambda: |-
-          return id(manual_offset_b);     // Return the global
+      then:
+        - lambda: |-
+            id(manual_offset_b) = (int) x;
+ 
   - platform: template
     id: offset_c_number
     name: "Offset C (0-3300)"
     restore_value: true       # <--- important
+    optimistic: true
     initial_value: 0
     min_value: 0
     max_value: 3300
     step: 1
-    set_action:
-      - lambda: |-
-          id(manual_offset_c) = (int) x;
     on_value:
-      lambda: |-
-          return id(manual_offset_c);     // Return the global
+      then:
+        - lambda: |-
+            id(manual_offset_c) = (int) x;
 
 
 
@@ -601,7 +600,10 @@ dashboard_import:
 wifi:
   # Set up a wifi access point using the device name above
   ap:
-
+  manual_ip:
+    static_ip: 192.168.1.84
+    gateway: 192.168.1.1
+    subnet: 255.255.255.0
 # In combination with the `ap` this allows the user
 # to provision wifi credentials to the device.
 captive_portal:

--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -1,5 +1,3 @@
-
-
 # These substitutions allow the end user to override certain values
 substitutions:
   name: "muino-water-meter"
@@ -11,12 +9,6 @@ esphome:
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: "dio"
-
-  # This will allow for (future) project identification,
-  # configuration and updates.
-  project:
-    name: esphome.muino-water-meter
-    version: "3.0.4"
 
 esp32:
   board: seeed_xiao_esp32c3

--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -1,3 +1,5 @@
+
+
 # These substitutions allow the end user to override certain values
 substitutions:
   name: "muino-water-meter"
@@ -9,6 +11,12 @@ esphome:
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: "dio"
+
+  # This will allow for (future) project identification,
+  # configuration and updates.
+  project:
+    name: esphome-muino-water-meter
+    version: "3.0.4"
 
 esp32:
   board: seeed_xiao_esp32c3
@@ -585,7 +593,7 @@ api:
 ota:
   platform: esphome
 
-# # This should point to the public location of this yaml file.
+# This should point to the public location of this yaml file.
 # dashboard_import:
 #   package_import_url: github://martijnvwezel/watermeter-esphome/muino-water-meter-esp32.yaml@main
 

--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -600,10 +600,10 @@ dashboard_import:
 wifi:
   # Set up a wifi access point using the device name above
   ap:
-  manual_ip:
-    static_ip: 192.168.1.84
-    gateway: 192.168.1.1
-    subnet: 255.255.255.0
+  # manual_ip:
+  #   static_ip: 192.168.1.84
+  #   gateway: 192.168.1.1
+  #   subnet: 255.255.255.0
 # In combination with the `ap` this allows the user
 # to provision wifi credentials to the device.
 captive_portal:


### PR DESCRIPTION
# How It Works
## Manual Calibration Switch (calibration_mode):
* When ON, subtract manual offsets (manual_offset_a/b/c) instead of auto-calibrated values. For some meters the max or min can go to very high or low values depending on the used meter. For those setups a manual zero crossing value is more robust. Normally that value has to be setup once only.
* The signal represends a sinus wave and to convert a sinus to liters I use the method auto-correlation  so the zero crossing has to be between the actual max min of the sinus wave.
## Offset values:
* In Home Assistant will appear 3 values that are the offsets of the meter. Basically, setting the value ` manual_offset_a/b/c = (max_a/b/c - min_a/b/c)/2 ` 


Compatible with current ESPHome releases (2024.11.3+).