### PR TITLE
Fix ha warnings

### DIFF
--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -377,14 +377,14 @@ sensor:
     id: report_liters
     force_update: false
     device_class: "water"
-    unit_of_measurement: "mL"
-    accuracy_decimals: 0 
+    unit_of_measurement: "L"
+    accuracy_decimals: 3 
     state_class: total_increasing
     lambda: |-
       if (id(liters) < 2){
         return 0;
       }    
-      return id(last_reported_liters__mili);
+      return id(last_reported_liters__mili) / 1000.0;
 
   - platform: template
     name: "liters"

--- a/muino-water-meter-esp32.yaml
+++ b/muino-water-meter-esp32.yaml
@@ -429,7 +429,6 @@ sensor:
     device_class: "water"
     unit_of_measurement: "L"
     accuracy_decimals: 1
-    state_class: measurement
     lambda: |-
       return id(current_consumption);
 
@@ -440,7 +439,6 @@ sensor:
     device_class: "water"
     unit_of_measurement: "L"
     accuracy_decimals: 1
-    state_class: measurement
     lambda: |-
       return id(previous_consumption);
 


### PR DESCRIPTION
Would close #78.

As mentioned in issue:

> The fix would be relatively easy (make `water_liter_sensor` work with `L` and remove `state_class: measurement` from `current_consumption_sensor` and `previous_consumption_sensor`. The latter will trigger a one-time repair that cannot be ignored urging to remove statistics.

It did work when employing to my own watermeter:
```
packages:
  esphome.muino-water-meter: github://gerritjandebruin/watermeter-esphome/muino-water-meter-esp32.yaml@fix-ha-warnings
```